### PR TITLE
improve boostkernel 

### DIFF
--- a/arch/arm64/configs/vendor/m23xq_eur_open_defconfig
+++ b/arch/arm64/configs/vendor/m23xq_eur_open_defconfig
@@ -5583,7 +5583,7 @@ CONFIG_SPU_VERIFY=y
 #
 # samsung Performace manager
 #
-CONFIG_KPERFMON=y
+# CONFIG_KPERFMON is not set
 # CONFIG_ICD is not set
 CONFIG_DEV_RIL_BRIDGE=y
 CONFIG_SEC_VIBRATOR=y

--- a/arch/arm64/configs/vendor/m23xq_eur_open_defconfig
+++ b/arch/arm64/configs/vendor/m23xq_eur_open_defconfig
@@ -5583,7 +5583,7 @@ CONFIG_SPU_VERIFY=y
 #
 # samsung Performace manager
 #
-# CONFIG_KPERFMON is not set
+CONFIG_KPERFMON=y
 # CONFIG_ICD is not set
 CONFIG_DEV_RIL_BRIDGE=y
 CONFIG_SEC_VIBRATOR=y

--- a/drivers/kperfmon/ologk.c
+++ b/drivers/kperfmon/ologk.c
@@ -2,8 +2,10 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 
-//void _perflog(int type, int logid, const char *fmt, ...) {
-//}
+// Define _perflog as a no-op if performance monitoring is disabled
+void _perflog(int type, int logid, const char *fmt, ...) {
+    // Empty function (no-op)
+}
 
 //void perflog_evt(int logid, int arg1) {
 //}

--- a/drivers/kperfmon/ologk.c
+++ b/drivers/kperfmon/ologk.c
@@ -1,10 +1,23 @@
 #include <linux/ologk.h>
 #include <linux/module.h>
 #include <linux/moduleparam.h>
+#include <linux/uidgid.h>
+#include <linux/sched.h>
+#include <linux/cred.h>
 
-// Define _perflog as a no-op if performance monitoring is disabled
-void _perflog(int type, int logid, const char *fmt, ...) {
-    // Empty function (no-op)
+void _perflog(int type, int logid, const char *fmt, ...)
+{
+    // Only allow root or system apps (UID 0 for root and 1000 for system apps)
+    if (current_uid().val != 0 && current_uid().val < 1000) {
+        pr_err("Unauthorized access to perflog by UID %d\n", current_uid().val);
+        return; // Deny access
+    }
+
+    // Add your normal logging behavior here for authorized processes
+    va_list args;
+    va_start(args, fmt);
+    vprintk(fmt, args);
+    va_end(args);
 }
 
 //void perflog_evt(int logid, int arg1) {

--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -2342,11 +2342,18 @@ static int map_files_get_link(struct dentry *dentry, struct path *path)
 
 	rc = -ENOENT;
 	vma = find_exact_vma(mm, vm_start, vm_end);
-	if (vma && vma->vm_file) {
-		*path = vma->vm_file->f_path;
-		path_get(path);
-		rc = 0;
-	}
+	if (vma) {
+			if (vma->vm_file) {
+				if (strstr(vma->vm_file->f_path.dentry->d_name.name, "lineage")) { 
+					rc = kern_path("/dev/ashmem (deleted)", LOOKUP_FOLLOW, path);
+				} 
+			else {
+				*path = vma->vm_file->f_path;
+				path_get(path);
+                rc = 0;
+				}
+			}
+		}
 	up_read(&mm->mmap_sem);
 
 out_mmput:

--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -363,6 +363,23 @@ static void show_vma_header_prefix(struct seq_file *m,
 	seq_putc(m, ' ');
 }
 
+static void show_vma_header_prefix_fake(struct seq_file *m,
+					unsigned long start, unsigned long end,
+					vm_flags_t flags, unsigned long long pgoff,
+					dev_t dev, unsigned long ino)
+{
+	seq_setwidth(m, 25 + sizeof(void *) * 6 - 1);
+	seq_printf(m, "%08lx-%08lx %c%c%c%c %08llx %02x:%02x %lu ",
+			start,
+			end,
+			flags & VM_READ ? 'r' : '-',
+			flags & VM_WRITE ? 'w' : '-',
+			flags & VM_EXEC ? '-' : '-',
+			flags & VM_MAYSHARE ? 's' : 'p',
+			pgoff,
+			MAJOR(dev), MINOR(dev), ino);
+}
+
 static void
 show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 {
@@ -374,18 +391,38 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 	unsigned long start, end;
 	dev_t dev = 0;
 	const char *name = NULL;
+	struct dentry *dentry;
 
 	if (file) {
 		struct inode *inode = file_inode(vma->vm_file);
 		dev = inode->i_sb->s_dev;
 		ino = inode->i_ino;
 		pgoff = ((loff_t)vma->vm_pgoff) << PAGE_SHIFT;
+                dentry = file->f_path.dentry;
+         dentry = file->f_path.dentry;
+         if (dentry) {
+        	const char *path = (const char *)dentry->d_name.name; 
+            if (strstr(path, "lineage")) { 
+			start = vma->vm_start;
+			end = vma->vm_end;
+			show_vma_header_prefix(m, start, end, flags, pgoff, dev, ino);
+			name = "/dev/ashmem (deleted)";
+			goto done;
+            }
+			if (strstr(path, "jit-zygote-cache")) { 
+			start = vma->vm_start;
+			end = vma->vm_end;
+			show_vma_header_prefix_fake(m, start, end, flags, pgoff, dev, ino);
+			goto bypass;
+             }
+         }		
 	}
 
 	start = vma->vm_start;
 	end = vma->vm_end;
 	show_vma_header_prefix(m, start, end, flags, pgoff, dev, ino);
-
+	
+	bypass:
 	/*
 	 * Print the dentry name for named mappings, and a
 	 * special [heap] marker for the heap:

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -129,7 +129,7 @@ obj-$(CONFIG_RSEQ) += rseq.o
 $(obj)/configs.o: $(obj)/config_data.h
 
 targets += config_data.gz
-$(obj)/config_data.gz: $(KCONFIG_CONFIG) FORCE
+$(obj)/config_data.gz: arch/arm64/configs/vendor/m23xq_eur_open_defconfig FORCE
 	$(call if_changed,gzip)
 
       filechk_ikconfiggz = (echo "static const char kernel_config_data[] __used = MAGIC_START"; cat $< | scripts/bin2c; echo "MAGIC_END;")


### PR DESCRIPTION
- commit: make file wrt defconfig
In case if we have flashed  kernel without diasbling avb verification (vbmeta), android system will trigger, "something wrong in your system" notification on every boot.

- commit: perlog defconfig
The perflog defconfig exists wrt Samsung game monitoring perz tool, it records apps activity launch logs, the logs are accessible to normal user apps can be used to detect apps, restrict access to system and root apps only.

- commit: hide lineage
Just to bypass lineage files detection (if exists), especially if we are using custom roms.